### PR TITLE
Implement ServiceEndpoint.EndpointBehaviors

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Description/ServiceEndpoint.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Description/ServiceEndpoint.cs
@@ -68,9 +68,8 @@ namespace System.ServiceModel.Description
 			get { return behaviors; }
 		}
 
-		[MonoTODO]
 		public KeyedCollection<Type,IEndpointBehavior> EndpointBehaviors {
-			get { throw new NotImplementedException (); }
+			get { return behaviors; }
 		}
 
 		public ContractDescription Contract {


### PR DESCRIPTION
This follows the reference source in understanding `EndpointBehaviors` to be an alias of `Behaviors` with a more general type.

Note that although an alias might not seem necessary to implement, when using netstandard1.3 the [`System.ServiceModel.Primitives`](https://www.nuget.org/packages/System.ServiceModel.Primitives) package exposes `EndpointBehaviors` but not `Behaviors`.